### PR TITLE
fixing ordering for noise_psd on udp send

### DIFF
--- a/c-udp/PulseInfoStruct.m
+++ b/c-udp/PulseInfoStruct.m
@@ -14,12 +14,12 @@ classdef PulseInfoStruct < handle
         group_seq_counter           (1, 1) double = NaN;
         group_ind                   (1, 1) double = NaN;
         group_snr                   (1, 1) double = NaN;
+        noise_psd                   (1, 1) double = NaN;
         detection_status            (1, 1) double = NaN;
         confirmed_status            (1, 1) double = NaN;
         udpSender                   (1, 1)
         udpReceiver                 (1, 1)
         cDoubles                    (1, 1) uint32 = 11;     % Must match the number of double sent/received over udp in a single packet
-        noise_psd                   (1, 1) double = NaN;
     end
 
     methods
@@ -122,9 +122,9 @@ classdef PulseInfoStruct < handle
                                 self.group_seq_counter ...
                                 self.group_ind ...
                                 self.group_snr ...
+                                self.noise_psd ...
                                 self.detection_status ...
                                 self.confirmed_status ...
-                                self.noise_psd ...
                             ];
         end
 
@@ -138,9 +138,9 @@ classdef PulseInfoStruct < handle
                                 0.0 ... % self.group_seq_counter ...
                                 0.0 ... % self.group_ind ...
                                 0.0 ... % self.group_snr ...
+                                0.0 ... % self.noise_psd ...
                                 0.0 ... % self.detection_status ...
                                 0.0 ... % self.confirmed_status ...
-                                0.0 ... % self.noise_psd ...
                             ];
         end
 
@@ -154,9 +154,9 @@ classdef PulseInfoStruct < handle
             self.group_seq_counter           = doublesBuffer(7);
             self.group_ind                   = doublesBuffer(8);
             self.group_snr                   = doublesBuffer(9);
-            self.detection_status            = doublesBuffer(10);
-            self.confirmed_status            = doublesBuffer(11);
-            self.noise_psd                   = doublesBuffer(12);
+            self.noise_psd                   = doublesBuffer(10);
+            self.detection_status            = doublesBuffer(11);
+            self.confirmed_status            = doublesBuffer(12);
         end
     end
 end


### PR DESCRIPTION
This is likely what was causing the issue with the pulse logs at TagTracker having bad noise_psd, det_status, and con_status entries. 